### PR TITLE
Fix for Manifest issue when using as a Gemspec (Issue 4)

### DIFF
--- a/uniquify.gemspec
+++ b/uniquify.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.description = %q{Generate a unique token with Active Record.}
   s.email = %q{ryan@railscasts.com}
   s.extra_rdoc_files = ["lib/uniquify.rb", "README.rdoc"]
-  s.files = ["lib/uniquify.rb", "Rakefile", "README.rdoc", "Manifest", "uniquify.gemspec"]
+  s.files = ["lib/uniquify.rb", "Rakefile", "README.rdoc", "uniquify.gemspec"]
   s.has_rdoc = true
   s.homepage = %q{http://github.com/ryanb/uniquify}
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Uniquify", "--main", "README.rdoc"]


### PR DESCRIPTION
This pull request is a fix for those trying to use this as a Gem related to https://github.com/ryanb/uniquify/issues/4. It just removes "Manifest" from the files list. 
